### PR TITLE
Fix scheduling

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -18,3 +18,27 @@
   listen: systemctl daemon-reload
   when:
     - "ansible_service_mgr == 'systemd'"
+
+- name: Enable full backup timer
+  systemd:
+    name: "{{ pgbackrest_systemd_timer_name }}-full.timer"
+    enabled: true
+  listen: systemctl enable pgbackrest-backup-full.timer
+  when:
+    - "ansible_service_mgr == 'systemd'"
+
+- name: Enable differential backup timer
+  systemd:
+    name: "{{ pgbackrest_systemd_timer_name }}-diff.timer"
+    enabled: true
+  listen: systemctl enable pgbackrest-backup-diff.timer
+  when:
+    - "ansible_service_mgr == 'systemd'"
+
+- name: Enable incremental backup timer
+  systemd:
+    name: "{{ pgbackrest_systemd_timer_name }}-incr.timer"
+    enabled: true
+  listen: systemctl enable pgbackrest-backup-incr.timer
+  when:
+    - "ansible_service_mgr == 'systemd'"

--- a/tasks/schedule.yml
+++ b/tasks/schedule.yml
@@ -1,4 +1,18 @@
 ---
+- name: Disable timers if the systemd timer is disabled
+  systemd:
+    name: "{{ _systemd_timer }}"
+    enabled: false
+  loop:
+    - "{{ pgbackrest_systemd_timer_name }}-full.timer"
+    - "{{ pgbackrest_systemd_timer_name }}-diff.timer"
+    - "{{ pgbackrest_systemd_timer_name }}-incr.timer"
+  loop_control:
+    loop_var: _systemd_timer
+  when:
+    - "ansible_service_mgr == 'systemd'"
+    - "not pgbackrest_systemd_timer_enabled"
+
 - name: >-
     Remove systemd .service and .timer files if the systemd timer is disbabled
   file:

--- a/tasks/schedule.yml
+++ b/tasks/schedule.yml
@@ -4,7 +4,8 @@
   file:
     path: "{{ _pgbackrest_systemd_file }}"
     state: absent
-  notify: systemctl daemon-reload
+  notify:
+    - systemctl daemon-reload
   loop:
     - "/etc/systemd/system/{{ pgbackrest_systemd_timer_name }}-full.service"
     - "/etc/systemd/system/{{ pgbackrest_systemd_timer_name }}-full.timer"
@@ -21,7 +22,8 @@
   file:
     path: "{{ _pgbackrest_systemd_file }}"
     state: absent
-  notify: systemctl daemon-reload
+  notify:
+    - systemctl daemon-reload
   loop:
     - "/etc/systemd/system/{{ pgbackrest_systemd_timer_name }}-diff.service"
     - "/etc/systemd/system/{{ pgbackrest_systemd_timer_name }}-diff.timer"
@@ -39,7 +41,8 @@
   file:
     path: "{{ _pgbackrest_systemd_file }}"
     state: absent
-  notify: systemctl daemon-reload
+  notify:
+    - systemctl daemon-reload
   loop:
     - "/etc/systemd/system/{{ pgbackrest_systemd_timer_name }}-incr.service"
     - "/etc/systemd/system/{{ pgbackrest_systemd_timer_name }}-incr.timer"
@@ -58,7 +61,8 @@
     owner: root
     group: root
     mode: "0644"
-  notify: systemctl daemon-reload
+  notify:
+    - systemctl daemon-reload
   vars:
     pgbackrest_systemd_timer_oncalendar: "{{ pgbackrest_full_backup_systemd_timer_oncalendar }}"
     _pgbackrest_backup_type: full
@@ -73,7 +77,9 @@
     owner: root
     group: root
     mode: "0644"
-  notify: systemctl daemon-reload
+  notify:
+    - systemctl daemon-reload
+    - systemctl enable pgbackrest-backup-full.timer
   vars:
     pgbackrest_systemd_timer_oncalendar: "{{ pgbackrest_full_backup_systemd_timer_oncalendar }}"
   when:
@@ -87,7 +93,8 @@
     owner: root
     group: root
     mode: "0644"
-  notify: systemctl daemon-reload
+  notify:
+    - systemctl daemon-reload
   vars:
     pgbackrest_systemd_timer_oncalendar: >-
       {{ pgbackrest_diff_backup_systemd_timer_oncalendar }}
@@ -104,7 +111,9 @@
     owner: root
     group: root
     mode: "0644"
-  notify: systemctl daemon-reload
+  notify:
+    - systemctl daemon-reload
+    - systemctl enable pgbackrest-backup-diff.timer
   vars:
     pgbackrest_systemd_timer_oncalendar: >-
       {{ pgbackrest_diff_backup_systemd_timer_oncalendar }}
@@ -120,7 +129,8 @@
     owner: root
     group: root
     mode: "0644"
-  notify: systemctl daemon-reload
+  notify:
+    - systemctl daemon-reload
   vars:
     pgbackrest_systemd_timer_oncalendar: >-
       {{ pgbackrest_incr_backup_systemd_timer_oncalendar }}
@@ -137,7 +147,9 @@
     owner: root
     group: root
     mode: "0644"
-  notify: systemctl daemon-reload
+  notify:
+    - systemctl daemon-reload
+    - systemctl enable pgbackrest-backup-incr.timer
   vars:
     pgbackrest_systemd_timer_oncalendar: >-
       {{ pgbackrest_incr_backup_systemd_timer_oncalendar }}
@@ -148,7 +160,7 @@
 
 - name: Install the pgbackrest full backup cron job
   ansible.builtin.cron:
-    name: "pgbackrest backup schedule"
+    name: "pgbackrest full backup schedule"
     cron_file: pgbackrest
     job: >-
       {{ pgbackrest_backup_script_path }}
@@ -175,7 +187,7 @@
 
 - name: Install the pgbackrest differential backup cron job
   ansible.builtin.cron:
-    name: "pgbackrest backup schedule"
+    name: "pgbackrest diff backup schedule"
     cron_file: pgbackrest
     job: >-
       {{ pgbackrest_backup_script_path }}
@@ -205,7 +217,7 @@
 
 - name: Install the pgbackrest incremental backup cron job
   ansible.builtin.cron:
-    name: "pgbackrest backup schedule"
+    name: "pgbackrest incremental backup schedule"
     cron_file: pgbackrest
     job: >-
       {{ pgbackrest_backup_script_path }}


### PR DESCRIPTION
Fix to the cron job names to avoid having the different ones (full, diff and incr) clobber eachother.

This also actually enables systemd timers if they've been selected